### PR TITLE
Fix issue using sort method

### DIFF
--- a/3월/20200330/javascript/완주하지_못한_선수/whoHasNotFinished.test.js
+++ b/3월/20200330/javascript/완주하지_못한_선수/whoHasNotFinished.test.js
@@ -1,14 +1,7 @@
 const solution = (participant, completion) => {
-  const sortedParticipant = participant.sort();
-  const sortedCompletion = completion.sort();
-
-  for (let i = 0; i < participant.length; i++) {
-    if (
-      sortedParticipant[i] !== sortedCompletion[i] ||
-      sortedCompletion == undefined
-    )
-      return sortedParticipant[i];
-  }
+  const participants = [...participant].sort();
+  const completions = [...completion].sort();
+  return participants.find((it, index) => it !== completions[index]);
 };
 
 test("solution", () => {


### PR DESCRIPTION
윤석님의 코드 리뷰에 따라 코드를 수정했다. Shout 윤석 :)

sort() 메서드는 배열을 직접 수정한다.
- 기존의 코드는 sortedParticipant 변수에 participant 배열을 정렬한
  새로운 배열을 반환하는 것으로 생각했다.
- 하지만 sort()는 배열을 직접 수정하므로 participant와
  sortedParticipant는 같은 메모리를 가리키게 된다.
- 따라서 확장연산자를 이용해 participant를 복사한 배열을 정렬하여 새로운
  변수에 할당해야 한다.

복수개를 표현하는 영단어를 잘 활용하자.
- sortedParticipant 변수 이름을 지을 때 참 난감했다.
- 너무 길고 불편했는데, 그냥 s 붙이면 될 걸 이 생각을 못했다.
- sortedParticipant -> participants

어떤 경우인지 알 수 없는 가독성 떨어지는 코드
- sortedCompletion == undefined 는 어떤 경우인지 알기 어렵다.
- 이에 대한 경우를 테스트 케이스에 추가해서 보여주는게 좋다.

특정 조건에 맞는 것을 찾아주는 find 메소드
- find 메소드는 주어진 판별 함수를 만족하는 첫 번째 요소의 값을
  반환한다.
- 그런 요소가 없다면 undefined 를 반환한다.